### PR TITLE
hamamatsu test

### DIFF
--- a/hamamatsu.py
+++ b/hamamatsu.py
@@ -515,7 +515,7 @@ class Hamamatsu(Instrument):
             else:
                 # A failed measurement returns useless data of all 0
                 flat_ar = np.zeroes(sz[1]*sz[2])
-            tmp_str = u16_ar_to_str(flat_ar)
+            tmp_str = u16_ar_to_bytes(flat_ar)
             hm_str += TCP.format_data(f"{hm}/shots/{shot}", tmp_str)
 
         hm_str += TCP.format_data(f"{hm}/temperature", "{:.3f}".format(self.camera_temp))
@@ -523,14 +523,13 @@ class Hamamatsu(Instrument):
         return hm_str
 
 
-def u16_ar_to_str(ar: np.ndarray) -> str:  # Should the type hint on the return be modified?
+def u16_ar_to_bytes(ar: np.ndarray) -> bytes:
     """
     Converts ar to a string encoded as useful for parsing xml messages sent back to cspy
 
     Args:
         ar : input array. should be 1D ndarray
     Returns:
-        string that's parsable by cspy xml reciever
+        string to be parsed by cspy xml receiver
     """
-
     return struct.pack(f"!{len(ar)}H", *ar)

--- a/hamamatsu_test.py
+++ b/hamamatsu_test.py
@@ -1,0 +1,17 @@
+import numpy as np
+import struct
+import pytest
+from hamamatsu import u16_ar_to_bytes
+
+
+def test_u16_ar_to_bytes():
+    for trial in range(10):
+        random_arr = np.random.randint(0, 65535, size=(100,), dtype=np.uint16)
+        mess = u16_ar_to_bytes(random_arr)
+        # Equivalent code is used to parse the message on the CsPy side
+        parsed_arr = np.array(struct.unpack(f'!{int(len(mess)/2)}H', mess), dtype=np.uint16)
+        assert np.allclose(random_arr, parsed_arr)
+
+    with pytest.raises(TypeError, match="only integer scalar arrays can be converted"):
+        bad_shape = random_arr.reshape((100, 1))
+        u16_ar_to_bytes(bad_shape)


### PR DESCRIPTION
Adds a "round trip" style test for the bytes packing method in Hamamatsu. For this I've just copied the parsing code from cspy and converted it to a python 3 version. It may be useful for us to design actual round trip tests once we have live operation confirmed but this will do for now.