### PR TITLE
Return Data 'n Errors

### DIFF
--- a/analogout.py
+++ b/analogout.py
@@ -172,8 +172,8 @@ class AnalogOutput(Instrument):
                     self.task = nidaqmx.Task() # might be task.Task()
                     self.task.ao_channels.add_ao_voltage_chan(
                         self.physicalChannels,
-                        min_val = self.minValue,
-                        max_val = self.maxValue)
+                        min_val=self.minValue,
+                        max_val=self.maxValue)
                     
                     if self.externalClock.useExternalClock:
                         self.task.timing.cfg_samp_clk_timing(
@@ -228,6 +228,7 @@ class AnalogOutput(Instrument):
                 self.stop()
                 self.close()
                 msg = '\n AnalogOutput hardware update failed'
+                self.is_initialized = False
                 raise HardwareError(self, task=self.task, message=msg)
 
     def is_done(self) -> bool:
@@ -251,6 +252,7 @@ class AnalogOutput(Instrument):
                 self.stop()
                 self.close()
                 msg = '\n AnalogOutput check for task completion failed'
+                self.is_initialized = False
                 raise HardwareError(self, task=self.task, message=msg)
 
         return done
@@ -270,6 +272,7 @@ class AnalogOutput(Instrument):
                 self.stop()
                 self.close()
                 msg = '\n AnalogOutput failed to start task'
+                self.is_initialized = False
                 raise HardwareError(self, task=self.task, message=msg)
 
     def stop(self):
@@ -284,6 +287,7 @@ class AnalogOutput(Instrument):
             except DaqError:
                 self.close()
                 msg = '\n AnalogOutput failed to stop current task'
+                self.is_initialized = False
                 raise HardwareError(self, task=self.task, message=msg)
 
     def close(self):
@@ -297,4 +301,5 @@ class AnalogOutput(Instrument):
                 
             except DaqError:
                 msg = '\n AnalogOutput failed to close current task'
+                self.is_initialized = False
                 raise HardwareError(self, task=self.task, message=msg)

--- a/digitalin.py
+++ b/digitalin.py
@@ -35,8 +35,7 @@ class TTLInput(Instrument):
         self.data_string = ""
         self.task = None
         self.lines = ""
-        
-        
+
     def load_xml(self, node: ET.Element):
         """
         Initialize the instrument class attributes from XML received from CsPy
@@ -71,7 +70,6 @@ class TTLInput(Instrument):
                             
                 except ValueError:
                     raise XMLError(self, child)
-                        
     
     def init(self):
         """
@@ -113,7 +111,6 @@ class TTLInput(Instrument):
                 raise HardwareError(self, task=self.task, message=msg)
 
             self.is_initialized = True
-            
     
     def reset_data(self):
         """
@@ -125,7 +122,6 @@ class TTLInput(Instrument):
         # don't think it's initializing an array of that size-- just stating the default capacity
         # of that data type, because all of the elements are greyed out
         self.data = np.array([]) 
-                
 
     # TODO: see what kind of data we actually get when this runs
     def check(self):
@@ -144,7 +140,7 @@ class TTLInput(Instrument):
                 # 1 second timeout
                 data = self.task.read(timeout=1)
                 
-                #for debugging:
+                # for debugging:
                 self.logger.debug('TTL Data out: ', data)
                 
                 # get data out and append it to the extant data array
@@ -161,7 +157,6 @@ class TTLInput(Instrument):
                 self.close()
                 msg = '\n TTLInput data check failed'
                 raise HardwareError(self, task=self.task, message=msg)
-                
             
     def data_out(self) -> str:
         """
@@ -185,7 +180,6 @@ class TTLInput(Instrument):
                 
             return self.data_string
             
-            
     def start(self):
         """
         Start the task
@@ -202,7 +196,6 @@ class TTLInput(Instrument):
                 msg = '\n TTLInput failed to start task'
                 raise HardwareError(self, task=self.task, message=msg)
             
-            
     def stop(self):
         """
         Stop the task
@@ -214,7 +207,6 @@ class TTLInput(Instrument):
             except DaqError:
                 msg = '\n TTLInput failed while attempting to stop current task'
                 raise HardwareError(self, task=self.task, message=msg)
-                
                 
     def close(self):
         """

--- a/digitalin.py
+++ b/digitalin.py
@@ -51,9 +51,12 @@ class TTLInput(Instrument):
         assert (node.tag == self.expectedRoot,
                 f"Expected tag <{self.expectedRoot}>, but received <{node.tag}>")
         
-        if not (self.stop_connections or self.reset_connection):
+        if not (self.exit_measurement or self.stop_connections):
 
-            for child in node: 
+            for child in node:
+
+                if self.exit_measurement or self.stop_connections:
+                    break
             
                 try:
                     
@@ -67,7 +70,6 @@ class TTLInput(Instrument):
                         self.logger.warning(f"Unrecognized XML tag \'{child.tag}\' in <{self.expectedRoot}>")
                             
                 except ValueError:
-                    
                     raise XMLError(self, child)
                         
     
@@ -76,7 +78,7 @@ class TTLInput(Instrument):
         Initialize the device hardware with the attributes set in load_xml
         """
     
-        if not (self.stop_connections or self.reset_connection) and self.enable:
+        if not (self.stop_connections or self.exit_measurement) and self.enable:
                         
             # Clear old task
             if self.task is not None:
@@ -133,7 +135,7 @@ class TTLInput(Instrument):
         TODO: need to implement error checking here
         """
         
-        if not (self.stop_connections or self.reset_connection) and self.enable:
+        if not (self.stop_connections or self.exit_measurement) and self.enable:
             
             self.start()
             
@@ -169,7 +171,7 @@ class TTLInput(Instrument):
             the instance's data string, formatted for reception by CsPy
         """
         
-        if not (self.stop_connections or self.reset_connection) and self.enable:
+        if not (self.stop_connections or self.exit_measurement) and self.enable:
         
             # flatten the data and convert to a str 
             data_shape = self.data.shape # default is (1, 2)... where is data actually received?
@@ -189,7 +191,7 @@ class TTLInput(Instrument):
         Start the task
         """
         
-        if not (self.stop_connections or self.reset_connection) and self.enable:
+        if not (self.stop_connections or self.exit_measurement) and self.enable:
             
             try:
                 self.task.start()

--- a/digitalout.py
+++ b/digitalout.py
@@ -3,10 +3,6 @@ DAQmx Digital Output class for the PXI Server
 SaffmanLab, University of Wisconsin - Madison
 """
 
-# TODO: there exist DaqResourceWarning warnings that i neither handle nor log, 
-# as it seems that the class merely points to a built-in Python ResourceWarning, 
-# which is itself abstract. - Preston
-
 ## modules
 import nidaqmx
 from nidaqmx.constants import Edge, LineGrouping, AcquisitionType
@@ -29,8 +25,7 @@ class DAQmxDO(Instrument):
         self.physicalChannels = None
         self.startTrigger = StartTrigger()
         self.task = None
-        
-    
+
     def load_xml(self, node):
         """
         Initialize the instrument class attributes from XML received from CsPy
@@ -67,24 +62,26 @@ class DAQmxDO(Instrument):
 
                         # This is modifying the definitions of the outer for loop child and node. This
                         # seems dangerous.
-                        node = child
-                        for child in node:
+                        for grandchild in child:
 
                             if node.text == "waitForStartTrigger":
-                                self.startTrigger.wait_for_start_trigger = Instrument.str_to_bool(child.text)
-                            elif child.text == "source":
-                                self.startTrigger.source = child.text
-                            elif child.text == "edge":
+                                self.startTrigger.wait_for_start_trigger = Instrument.str_to_bool(grandchild.text)
+                            elif grandchild.text == "source":
+                                self.startTrigger.source = grandchild.text
+                            elif grandchild.text == "edge":
                                 try:
                                     # CODO: could make dictionary keys in StartTrigger
                                     # lowercase and then just .lower() the capitalized keys
                                     # passed in elsewhere
-                                    text = child.text[0].upper() + child.text[1:]
+                                    text = grandchild.text[0].upper() + grandchild.text[1:]
                                     self.startTrigger.edge = StartTrigger.nidaqmx_edges[text]
                                 except KeyError as e:
-                                    raise KeyError(f"Not a valid {child.tag} value {child.text} \n {e}")
+                                    raise KeyError(f"Not a valid {grandchild.tag} value {grandchild.text} \n {e}")
                             else:
-                                self.logger.warning(f"Unrecognized XML tag \'{node.tag}\' in <{child.tag}>")
+                                self.logger.warning(
+                                    f"Unrecognized XML tag \'{grandchild.tag}\'" +
+                                    f" in <{child.tag}> in <{self.expectedRoot}>"
+                                )
 
                     elif child.tag == "waveform":
                         self.waveform = Waveform()
@@ -102,8 +99,7 @@ class DAQmxDO(Instrument):
 
                 except (KeyError, ValueError):
                     raise XMLError(self, child)
-                
-                    
+
     def init(self):
         """
         Initialize the device hardware with the attributes set in load_xml
@@ -111,56 +107,55 @@ class DAQmxDO(Instrument):
     
         if not (self.stop_connections or self.reset_connection) and self.enable:
             
-                # Clear old task
-                if self.task is not None:
-                    try:
-                        self.task.close()
-                        
-                    except DaqError:
-                        # end the task nicely
-                        self.stop()
-                        self.close()
-                        msg = '\n DAQmxDO failed to close current task'
-                        raise HardwareError(self, task=self.task, message=msg)
-
+            # Clear old task
+            if self.task is not None:
                 try:
-                    self.task = nidaqmx.Task() # might be task.Task()
-                    
-                    # Create digital out virtual channel
-                    self.task.do_channels.add_do_chan(
-                        lines=self.physicalChannels, 
-                        name_to_assign_to_lines="",
-                        line_grouping=LineGrouping.CHAN_FOR_ALL_LINES)
-                    
-                    # Setup timing. Use the onboard clock
-                    self.task.timing.cfg_samp_clk_timing(
-                        rate=self.clockRate, 
-                        active_edge=Edge.RISING, # default
-                        sample_mode=AcquisitionType.FINITE, # default
-                        samps_per_chan=self.samplesPerChannel) 
-                        
-                    # Optionally set up start trigger
-                    if self.startTrigger.wait_for_start_trigger:
-                        self.task.start_trigger.cfg_dig_edge_start_trig(
-                            trigger_source=self.startTrigger.source,
-                            trigger_edge=self.startTrigger.edge)
-                                                            
-                    # Write digital waveform 1 chan N samp
-                    # by default, auto starts
-                    self.task.write(
-                        self.data, 
-                        timeout=10.0) # default
-            
+                    self.task.close()
+
                 except DaqError:
                     # end the task nicely
                     self.stop()
                     self.close()
-                    msg = '\n DAQmxDO hardware initialization failed'
+                    msg = '\n DAQmxDO failed to close current task'
                     raise HardwareError(self, task=self.task, message=msg)
-                    
-                self.is_initialized = True
-                
-                
+
+            try:
+                self.task = nidaqmx.Task() # might be task.Task()
+
+                # Create digital out virtual channel
+                self.task.do_channels.add_do_chan(
+                    lines=self.physicalChannels,
+                    name_to_assign_to_lines="",
+                    line_grouping=LineGrouping.CHAN_FOR_ALL_LINES)
+
+                # Setup timing. Use the onboard clock
+                self.task.timing.cfg_samp_clk_timing(
+                    rate=self.clockRate,
+                    active_edge=Edge.RISING, # default
+                    sample_mode=AcquisitionType.FINITE, # default
+                    samps_per_chan=self.samplesPerChannel)
+
+                # Optionally set up start trigger
+                if self.startTrigger.wait_for_start_trigger:
+                    self.task.start_trigger.cfg_dig_edge_start_trig(
+                        trigger_source=self.startTrigger.source,
+                        trigger_edge=self.startTrigger.edge)
+
+                # Write digital waveform 1 chan N samp
+                # by default, auto start is True
+                self.task.write(
+                    self.data,
+                    timeout=10.0) # default
+
+            except DaqError:
+                # end the task nicely
+                self.stop()
+                self.close()
+                msg = '\n DAQmxDO hardware initialization failed'
+                raise HardwareError(self, task=self.task, message=msg)
+
+            self.is_initialized = True
+
     def is_done(self) -> bool:
         """
         Check if the tasks being run are completed
@@ -185,7 +180,6 @@ class DAQmxDO(Instrument):
                 raise HardwareError(self, task=self.task, message=msg)
             
         return done
-                
 
     def start(self):
         """
@@ -203,7 +197,6 @@ class DAQmxDO(Instrument):
                 msg = '\n DAQmxDO failed to start task'
                 raise HardwareError(self, task=self.task, message=msg)
 
-            
     def stop(self):
         """
         Stop the task
@@ -215,8 +208,7 @@ class DAQmxDO(Instrument):
             except DaqError:
                 msg = '\n DAQmxDO failed while attempting to stop current task'
                 raise HardwareError(self, task=self.task, message=msg)
-                
-                
+
     def close(self):
         """
         Close the task

--- a/hamamatsu.py
+++ b/hamamatsu.py
@@ -11,16 +11,13 @@ camera and initialization of the hardware of said camera.
 from ctypes import *
 import numpy as np
 import xml.etree.ElementTree as ET
-from ni_imaq import NIIMAQSession
+from ni_imaq import NIIMAQSession, SubArray, FrameGrabberAqRegion
 import re
 import struct
 from tcp import TCP
 from recordclass import recordclass as rc
 from instrument import Instrument
 from pxierrors import XMLError, IMAQError, HardwareError
-
-SubArray = rc('SubArray', ('left', 'top', 'width', 'height'))
-FrameGrabberAqRegion = rc('FrameGrabberAqRegion', ('left', 'right', 'top', 'bottom'))
 
 
 class Hamamatsu(Instrument):

--- a/hamamatsu.py
+++ b/hamamatsu.py
@@ -395,6 +395,7 @@ class Hamamatsu(Instrument):
         except IMAQError as e:
             ms = f"{e}\n Error beginning asynchronous acquisition"
             self.session.close()
+            self.is_initialized = False
             raise IMAQError(e.error_code, ms)
 
         try:
@@ -438,6 +439,7 @@ class Hamamatsu(Instrument):
             er_c, session_acquiring, last_buf_ind, last_buf_num = self.session.status()
         except IMAQError as e:
             ms = f"{e}\nError Reading out session status during measurement"
+            self.is_initialized = False
             raise IMAQError(e.error_code, ms)
 
         bf_dif = last_buf_num - self.last_frame_acquired
@@ -470,6 +472,7 @@ class Hamamatsu(Instrument):
                 er_c, bf_ind, img = self.session.extract_buffer(frame_ind)
             except IMAQError as e:
                 ms = f"{e}\nError acquiring buffer number {frame_ind} measurement abandoned"
+                self.is_initialized = False
                 raise IMAQError(e.error_code, ms)
             self.last_measurement[i, :, :] = img
 
@@ -495,6 +498,7 @@ class Hamamatsu(Instrument):
                     f"{e}\nError reading camera temperature",
                     exc_info=True)
                 self.camera_temp = np.inf
+                self.is_initialized = False
                 return
 
             m = re.match(r"TMP (\d+)\.(\d+)", msg_out)
@@ -535,6 +539,7 @@ class Hamamatsu(Instrument):
 
         except Exception as e:
             self.logger.exception(f"Error formatting data from {self.__class__.__name__}")
+            self.is_initialized = False
             raise e
 
         return hm_str

--- a/hamamatsu.py
+++ b/hamamatsu.py
@@ -13,7 +13,6 @@ import numpy as np
 import xml.etree.ElementTree as ET
 from ni_imaq import NIIMAQSession
 import re
-import logging
 import struct
 from tcp import TCP
 from recordclass import recordclass as rc

--- a/hamamatsu.py
+++ b/hamamatsu.py
@@ -116,113 +116,117 @@ class Hamamatsu(Instrument):
         
         super().load_xml(node)
 
-        for child in node:
-        
-            try:
-                # handle each tag by name:
-                if child.tag == "version":
-                    # labview code checks if camera settings are from
-                    # "2015.05.24", which is hardcoded. probably don't need
-                    # this case?
-                    # TODO : Check if this info is used anywhere in labview
-                    pass
-                elif child.tag == "enable":
-                    self.enable = self.str_to_bool(child.text)
+        if not (self.exit_measurement or self.stop_connections):
 
-                elif child.tag == "analogGain":
-                    gain = self.str_to_int(child.text)
-                    as_ms = f"analogGain = {gain}\n analogGain must be between 0  and 5"
-                    assert 0 < gain < 5, as_ms
-                    self.analog_gain = gain
+            for child in node:
 
-                elif child.tag == "exposureTime":
-                    # can convert scientifically-formatted numbers - good
-                    self.exposure_time = self.float(child.text)
+                if self.exit_measurement or self.stop_connections:
+                    break
 
-                elif child.tag == "EMGain":
-                    gain = self.str_to_int(child.text)
-                    as_ms = f"EMGain is {gain}\n EMGain must be between 0 and 255"
-                    assert 0 < gain < 255, as_ms
-                    self.em_gain = gain
+                try:
+                    # handle each tag by name:
+                    if child.tag == "version":
+                        # labview code checks if camera settings are from
+                        # "2015.05.24", which is hardcoded. probably don't need
+                        # this case?
+                        # TODO : Check if this info is used anywhere in labview
+                        pass
+                    elif child.tag == "enable":
+                        self.enable = self.str_to_bool(child.text)
 
-                elif child.tag == "triggerPolarity":
-                    self.set_by_dict("trigger_polarity", child.text, self.TRIG_POLARITY_VALUES)
+                    elif child.tag == "analogGain":
+                        gain = self.str_to_int(child.text)
+                        as_ms = f"analogGain = {gain}\n analogGain must be between 0  and 5"
+                        assert 0 < gain < 5, as_ms
+                        self.analog_gain = gain
 
-                elif child.tag == "externalTriggerMode":
-                    self.set_by_dict(
-                        "external_trigger_mode",
-                        child.text,
-                        self.EXT_TRIG_SOURCE_MODE_VALUES
-                    )
-                    
-                elif child.tag == "scanSpeed":
-                    self.set_by_dict("scan_speed", child.text, self.SCAN_SPEED_VALUES)
+                    elif child.tag == "exposureTime":
+                        # can convert scientifically-formatted numbers - good
+                        self.exposure_time = self.float(child.text)
 
-                elif child.tag == "lowLightSensitivity":
-                    self.set_by_dict(
-                        "low_light_sensitivity",
-                        child.text,
-                        self.LL_SENSITIVITY_VALUES
-                    )
+                    elif child.tag == "EMGain":
+                        gain = self.str_to_int(child.text)
+                        as_ms = f"EMGain is {gain}\n EMGain must be between 0 and 255"
+                        assert 0 < gain < 255, as_ms
+                        self.em_gain = gain
 
-                elif child.tag == "externalTriggerSource":
-                    self.set_by_dict(
-                        "external_trigger_source",
-                        child.text,
-                        self.EXT_TRIG_SOURCE_VALUES
-                    )
+                    elif child.tag == "triggerPolarity":
+                        self.set_by_dict("trigger_polarity", child.text, self.TRIG_POLARITY_VALUES)
 
-                elif child.tag == "cooling":
-                    self.set_by_dict("cooling", child.text, self.COOLING_VALUES)
+                    elif child.tag == "externalTriggerMode":
+                        self.set_by_dict(
+                            "external_trigger_mode",
+                            child.text,
+                            self.EXT_TRIG_SOURCE_MODE_VALUES
+                        )
 
-                elif child.tag == "fan":
-                    self.set_by_dict("fan", child.text, self.FAN_VALUES)
+                    elif child.tag == "scanSpeed":
+                        self.set_by_dict("scan_speed", child.text, self.SCAN_SPEED_VALUES)
 
-                elif child.tag == "scanMode":
-                    self.set_by_dict("scan_mode", child.text, self.SCAN_MODE_VALUES)
+                    elif child.tag == "lowLightSensitivity":
+                        self.set_by_dict(
+                            "low_light_sensitivity",
+                            child.text,
+                            self.LL_SENSITIVITY_VALUES
+                        )
 
-                elif child.tag == "superPixelBinning":
-                    self.super_pixel_binning = child.text
+                    elif child.tag == "externalTriggerSource":
+                        self.set_by_dict(
+                            "external_trigger_source",
+                            child.text,
+                            self.EXT_TRIG_SOURCE_VALUES
+                        )
 
-                elif child.tag == "subArrayLeft":
-                    self.sub_array.left = Instrument.str_to_int(child.text)
+                    elif child.tag == "cooling":
+                        self.set_by_dict("cooling", child.text, self.COOLING_VALUES)
 
-                elif child.tag == "subArrayTop":
-                    self.sub_array.top = Instrument.str_to_int(child.text)
+                    elif child.tag == "fan":
+                        self.set_by_dict("fan", child.text, self.FAN_VALUES)
 
-                elif child.tag == "subArrayWidth":
-                    self.sub_array.width = Instrument.str_to_int(child.text)
+                    elif child.tag == "scanMode":
+                        self.set_by_dict("scan_mode", child.text, self.SCAN_MODE_VALUES)
 
-                elif child.tag == "subArrayHeight":
-                    self.sub_array.height = Instrument.str_to_int(child.text)
+                    elif child.tag == "superPixelBinning":
+                        self.super_pixel_binning = child.text
 
-                elif child.tag == "frameGrabberAcquisitionRegionLeft":
-                    self.fg_acquisition_region.left = Instrument.str_to_int(child.text)
+                    elif child.tag == "subArrayLeft":
+                        self.sub_array.left = Instrument.str_to_int(child.text)
 
-                elif child.tag == "frameGrabberAcquisitionRegionTop":
-                    self.fg_acquisition_region.top = Instrument.str_to_int(child.text)
+                    elif child.tag == "subArrayTop":
+                        self.sub_array.top = Instrument.str_to_int(child.text)
 
-                elif child.tag == "frameGrabberAcquisitionRegionRight":
-                    self.fg_acquisition_region.right = Instrument.str_to_int(child.text)
+                    elif child.tag == "subArrayWidth":
+                        self.sub_array.width = Instrument.str_to_int(child.text)
 
-                elif child.tag == "frameGrabberAcquisitionRegionBottom":
-                    self.fg_acquisition_region.bottom = Instrument.str_to_int(child.text)
+                    elif child.tag == "subArrayHeight":
+                        self.sub_array.height = Instrument.str_to_int(child.text)
 
-                elif child.tag == "numImageBuffers":
-                    self.num_img_buffers = Instrument.str_to_int(child.text)
+                    elif child.tag == "frameGrabberAcquisitionRegionLeft":
+                        self.fg_acquisition_region.left = Instrument.str_to_int(child.text)
 
-                elif child.tag == "shotsPerMeasurement":
-                    self.shots_per_measurement = Instrument.str_to_int(child.text)
+                    elif child.tag == "frameGrabberAcquisitionRegionTop":
+                        self.fg_acquisition_region.top = Instrument.str_to_int(child.text)
 
-                elif child.tag == "forceImagesToU16":
-                    self.images_to_U16 = Instrument.str_to_bool(child.text)
+                    elif child.tag == "frameGrabberAcquisitionRegionRight":
+                        self.fg_acquisition_region.right = Instrument.str_to_int(child.text)
 
-                else:
-                    self.logger.warning(f"Node {child.tag} is not a valid Hamamatsu attribute")
+                    elif child.tag == "frameGrabberAcquisitionRegionBottom":
+                        self.fg_acquisition_region.bottom = Instrument.str_to_int(child.text)
 
-            except (KeyError, ValueError, AssertionError):
-                
-                raise XMLError(self, child)
+                    elif child.tag == "numImageBuffers":
+                        self.num_img_buffers = Instrument.str_to_int(child.text)
+
+                    elif child.tag == "shotsPerMeasurement":
+                        self.shots_per_measurement = Instrument.str_to_int(child.text)
+
+                    elif child.tag == "forceImagesToU16":
+                        self.images_to_U16 = Instrument.str_to_bool(child.text)
+
+                    else:
+                        self.logger.warning(f"Node {child.tag} is not a valid Hamamatsu attribute")
+
+                except (KeyError, ValueError, AssertionError):
+                    raise XMLError(self, child)
 
     def init(self):
         """

--- a/hsdio.py
+++ b/hsdio.py
@@ -128,8 +128,7 @@ class HSDIO(Instrument):
 
                 except ValueError: # maybe catch other errors too.
                     raise XMLError(self, child)
-                
-                
+
     def init(self):
         """
         set up the triggering, initial states, script triggers, etc
@@ -233,6 +232,7 @@ class HSDIO(Instrument):
                         )
                 except HSDIOError as e:
                     m = f"{e}\nError writing waveform. Waveform has not been updated",
+                    self.is_initialized = False
                     raise HSDIOError(e.error_code, m)
         self.wvf_written = True
 
@@ -267,6 +267,7 @@ class HSDIO(Instrument):
                 except HSDIOError:
                     session.abort()
                     session.close()
+                    self.is_initialized = False
                     raise
 
     def stop(self):

--- a/hsdio.py
+++ b/hsdio.py
@@ -67,63 +67,67 @@ class HSDIO(Instrument):
 
         super().load_xml(node)
 
-        for child in node:
+        if not (self.exit_measurement or self.stop_connections):
+
+            for child in node:
+
+                if self.exit_measurement or self.stop_connections:
+                    break
         
-            try:
+                try:
 
-                self.logger.debug(child)
-                # handle each tag by name:
-                if child.tag == "enable":
-                    self.enable = Instrument.str_to_bool(child.text)
+                    self.logger.debug(child)
+                    # handle each tag by name:
+                    if child.tag == "enable":
+                        self.enable = Instrument.str_to_bool(child.text)
 
-                elif child.tag == "description":
-                    self.description = child.text
+                    elif child.tag == "description":
+                        self.description = child.text
 
-                elif child.tag == "resourceName":
-                    resources = np.array(child.text.split(","))
-                    self.resourceNames = resources
+                    elif child.tag == "resourceName":
+                        resources = np.array(child.text.split(","))
+                        self.resourceNames = resources
 
-                elif child.tag == "clockRate":
-                    self.clockRate = float(child.text)
+                    elif child.tag == "clockRate":
+                        self.clockRate = float(child.text)
 
-                elif child.tag == "hardwareAlignmentQuantum":
-                    self.hardwareAlignmentQuantum = child.text
+                    elif child.tag == "hardwareAlignmentQuantum":
+                        self.hardwareAlignmentQuantum = child.text
 
-                elif child.tag == "triggers":
+                    elif child.tag == "triggers":
 
-                    if type(child) == ET.Element:
-                        trigger_node = child
-                        for t_child in trigger_node:
-                            self.scriptTriggers.append(Trigger(t_child))
+                        if type(child) == ET.Element:
+                            trigger_node = child
+                            for t_child in trigger_node:
+                                self.scriptTriggers.append(Trigger(t_child))
 
-                elif child.tag == "waveforms":
-                    self.logger.debug("found a waveform")
-                    wvforms_node = child
-                    for wvf_child in wvforms_node:
-                        if wvf_child.tag == "waveform":
-                            self.waveformArr.append(HSDIOWaveform(wvf_child))
+                    elif child.tag == "waveforms":
+                        self.logger.debug("found a waveform")
+                        wvforms_node = child
+                        for wvf_child in wvforms_node:
+                            if wvf_child.tag == "waveform":
+                                self.waveformArr.append(HSDIOWaveform(wvf_child))
 
-                elif child.tag == "script":
-                    self.pulseGenScript = child.text
+                    elif child.tag == "script":
+                        self.pulseGenScript = child.text
 
-                elif child.tag == "startTrigger":
-                    self.startTrigger = StartTrigger(child)
+                    elif child.tag == "startTrigger":
+                        self.startTrigger = StartTrigger(child)
 
-                elif child.tag == "InitialState":
-                    self.initialStates = np.array(child.text.split(","))
+                    elif child.tag == "InitialState":
+                        self.initialStates = np.array(child.text.split(","))
 
-                elif child.tag == "IdleState":
-                    self.idleStates = np.array(child.text.split(","))
+                    elif child.tag == "IdleState":
+                        self.idleStates = np.array(child.text.split(","))
 
-                elif child.tag == "ActiveChannels":
-                    self.activeChannels = np.array(child.text.split("\n"))
+                    elif child.tag == "ActiveChannels":
+                        self.activeChannels = np.array(child.text.split("\n"))
 
-                else:
-                    self.logger.warning(f"Unrecognized XML tag '{child.tag}' in <{self.expectedRoot}>")
-                    
-            except ValueError: # maybe catch other errors too. 
-                
-                raise XMLError(self, child)
+                    else:
+                        self.logger.warning(f"Unrecognized XML tag '{child.tag}' in <{self.expectedRoot}>")
+
+                except ValueError: # maybe catch other errors too.
+                    raise XMLError(self, child)
                 
                 
     def init(self):

--- a/hsdio.py
+++ b/hsdio.py
@@ -276,7 +276,10 @@ class HSDIO(Instrument):
         """
         if self.enable:
             for session in self.sessions:
-                session.abort()
+                try:
+                    session.abort()
+                except HSDIOError:
+                    raise
 
     def log_settings(self, wf_arr, wf_names):  # TODO : @Juan Implement
         pass

--- a/instrument.py
+++ b/instrument.py
@@ -134,7 +134,7 @@ class Instrument(XMLLoader):
             'pxi': reference to the parent PXI instance
             'expectedRoot': the xml tag corresponding to your instrument. This 
                 should be in the xml sent by CsPy to talk to setup this device.
-            'node': xml node if available, if passed self.load_xml is called in __init__
+            'node': xml node if available. if passed, self.load_xml is called in __init__
         """
         super().__init__(node)
         self.pxi = pxi
@@ -157,6 +157,14 @@ class Instrument(XMLLoader):
     @stop_connections.setter
     def stop_connections(self, value):
         self.pxi.stop_connections = value
+
+    @property
+    def exit_measurement(self) -> bool:
+        return self.pxi.exit_measurement
+
+    @exit_measurement.setter
+    def exit_measurement(self, value):
+        self.pxi.exit_measurement = value
    
     @abstractmethod
     def load_xml(self, node: ET.Element):
@@ -168,34 +176,11 @@ class Instrument(XMLLoader):
             node.tag == self.expectedRoot
         """
 
-        if self.stop_connections or self.reset_connection:
+        if not (self.exit_measurement or self.stop_connections):
             return
 
         as_ms = f"node to open camera is tagged {node.tag}. Must be tagged {self.expectedRoot}"
         assert node.tag == self.expectedRoot, as_ms
-
-        '''
-        Not sure any of this (except the self.enable setting) should be here -Juan
-
-        if not (self.stop_connections or self.reset_connection):
-        
-            assert node.tag == self.expectedRoot, f"Expected xml tag {self.expectedRoot}"
-
-            for child in node: 
-
-                if type(child) == ET.Element:
-                
-                    if child.tag == "enable":
-                        self.enable = self.str_to_bool(child.text)
-                
-                    # elif child.tag == "someOtherProperty":
-                        # self.thatProperty = child.text
-                    
-                    else:
-                        # TODO handle unexpected tag case
-                        # self.logger.warning(f"Unrecognized XML tag \'{child.tag}\' in <{self.expectedRoot}>")
-                        pass
-        '''
 
     @abstractmethod
     def init(self):

--- a/ni_hsdio.py
+++ b/ni_hsdio.py
@@ -4,25 +4,7 @@ import struct
 import platform # for checking the os bitness
 import logging
 from typing import Tuple
-from hsdio import HSDIO
-from pxierrors import HardwareError
-
-
-class HSDIOError(HardwareError):
-    """
-    Raised for errors coming from NI HSDIO drivers
-
-    Attributes:
-        error_code : Integer code representing the error state
-        message : message corresponding to the error_code with some traceback info
-    """
-    def __init__(self, error_code, message):
-        self.error_code = error_code
-        super().__init__(
-            device=HSDIO,
-            task=HSDIOSession,
-            message=message
-        )
+from pxierrors import HSDIOError
 
 
 class HSDIOSession:

--- a/ni_imaq.py
+++ b/ni_imaq.py
@@ -14,8 +14,10 @@ import os
 from ctypes import c_uint32
 from typing import Tuple, Callable, TypeVar
 import numpy as np
-from hamamatsu import SubArray, FrameGrabberAqRegion
 from pxierrors import IMAQError
+
+SubArray = rc('SubArray', ('left', 'top', 'width', 'height'))
+FrameGrabberAqRegion = rc('FrameGrabberAqRegion', ('left', 'right', 'top', 'bottom'))
 
 # Sub array acquisition RecordClasses for TypeHint convenience =================================
 ROI = TypeVar("ROI", SubArray, FrameGrabberAqRegion)

--- a/ni_imaq.py
+++ b/ni_imaq.py
@@ -14,8 +14,8 @@ import os
 from ctypes import c_uint32
 from typing import Tuple, Callable, TypeVar
 import numpy as np
-from hamamatsu import SubArray, FrameGrabberAqRegion, Hamamatsu
-from pxierrors import HardwareError, NIIMAQError
+from hamamatsu import SubArray, FrameGrabberAqRegion
+from pxierrors import IMAQError
 
 # Sub array acquisition RecordClasses for TypeHint convenience =================================
 ROI = TypeVar("ROI", SubArray, FrameGrabberAqRegion)

--- a/ni_imaq.py
+++ b/ni_imaq.py
@@ -14,29 +14,11 @@ import os
 from ctypes import c_uint32
 from typing import Tuple, Callable, TypeVar
 import numpy as np
-from recordclass import recordclass as rc
 from hamamatsu import SubArray, FrameGrabberAqRegion, Hamamatsu
-from pxierrors import HardwareError
+from pxierrors import HardwareError, NIIMAQError
 
 # Sub array acquisition RecordClasses for TypeHint convenience =================================
 ROI = TypeVar("ROI", SubArray, FrameGrabberAqRegion)
-
-
-class IMAQError(HardwareError):
-    """
-    Raised for errors coming from NI IMAQ drivers
-
-    Attributes:
-        error_code : Integer code representing the error state
-        message : message corresponding to the error_code with some traceback info
-    """
-    def __init__(self, error_code, message):
-        self.error_code = error_code
-        super().__init__(
-            device=Hamamatsu, 
-            task=NIIMAQSession,
-            message=message
-        )
 
 
 class NIIMAQSession:

--- a/pxi.py
+++ b/pxi.py
@@ -63,8 +63,8 @@ class PXI:
         # instantiate the device objects
         self.hsdio = HSDIO(self)
         self.tcp = TCP(self, address)
-        self.analog_input = AnalogOutput(self)
-        self.analog_output = AnalogInput(self)
+        self.analog_input = AnalogInput(self)
+        self.analog_output = AnalogOutput(self)
         self.ttl = TTLInput(self)
         self.daqmx_do = DAQmxDO(self)
         self.hamamatsu = Hamamatsu(self)
@@ -240,8 +240,8 @@ class PXI:
                     elif child.tag == "AnalogOutput":
                         # set up the analog_output
                         self.analog_output.load_xml(child)
-                        self.analog_output.init() # setup in labview
-                        self.analog_output.update() # TODO check why this doesn't exist
+                        self.analog_output.init()
+                        self.analog_output.update()
                         pass
 
                     elif child.tag == "AnalogInput":

--- a/pxi.py
+++ b/pxi.py
@@ -531,7 +531,7 @@ class PXI:
                 as sent to CsPy, warning the user that an error has occurred
                 and that the PXI settings should be updated.
             V. The current measurement cycle should be aborted, and restarted
-                if self.cycle_continuously == True. Class where error occurred
+                if self.cycle_continuously == True. Device where error occurred
                 should be excluded from the measurement cycle until it has been
                 reinitialized. I.e., devices which read/write signals (e.g.
                 TTLInput, HSDIO, etc) should continue to cycle if they can
@@ -539,9 +539,10 @@ class PXI:
                 coarsely, as many errors should result in the same handling
                 behavior in this function (e.g. all error types pertaining to an XML
                 initialization failure should result in a message urging the user to
-                check the XML in CsPy and reinitialize the device). Possible types
-                used here are HardwareError and XMLError, defined in pxierrors.py
-            
+                check the XML in CsPy and reinitialize the device). Specific
+                error types handled here are HardwareError and XMLError, defined
+                in pxierrors.py
+
         Args:
             error : The error that was raised. Maybe it's useful to keep it around
             traceback_str : string useful for traceback

--- a/pxi.py
+++ b/pxi.py
@@ -51,9 +51,8 @@ class PXI:
         self.logger = logging.getLogger(str(self.__class__))
         self._stop_connections = False
         self._reset_connection = False
-        self._stop_measurement = False
+        self._exit_measurement = False
         self.cycle_continuously = True
-        self.exit_measurement = False
         self.return_data = ""
         self.return_data_queue = ""
         self.measurement_timeout = 0
@@ -89,12 +88,12 @@ class PXI:
         self._reset_connection = value
         
     @property
-    def stop_measurement(self) -> bool:
-        return self._stop_measurement
+    def exit_measurement(self) -> bool:
+        return self._exit_measurement
         
-    @stop_measurement.setter
-    def stop_measurement(self, value):
-        self._stop_measurement = value
+    @exit_measurement.setter
+    def exit_measurement(self, value):
+        self._exit_measurement = value
 
     def queue_command(self, command):
         self.command_queue.put(command)
@@ -129,7 +128,7 @@ class PXI:
         hierarchy of methods in self.parse_xml and self.measurement.
         """
 
-        while not self.stop_connections or self.stop_measurement:
+        while not self.stop_connections or self.exit_measurement:
             try:
                 # dequeue xml; non-blocking
                 xml_str = self.command_queue.get(block=False, timeout=0)
@@ -601,9 +600,9 @@ class PXI:
         """
         Restart experiment thread after current measurement ends
         """
-        self.stop_measurement = True
+        self.exit_measurement = True
         self.experiment_thread.join() 
-        self.stop_measurement = False
+        self.exit_measurement = False
         self.launch_experiment_thread()
 
     def batch_method_call(self, device_list: List[Instrument], method: str):

--- a/pxierrors.py
+++ b/pxierrors.py
@@ -7,13 +7,10 @@ useful categories where specific handling action pertains to each type.
 """
 
 ## built-in modules
-from abc import ABC, abstractmethod
 import xml.etree.ElementTree as ET
 
 ## local class imports
 from instrument import XMLLoader
-from hsdio import HSDIO
-from ni_hsdio import HSDIOSession
 
 class PXIError(Exception):
     """

--- a/pxierrors.py
+++ b/pxierrors.py
@@ -12,8 +12,8 @@ import xml.etree.ElementTree as ET
 
 ## local class imports
 from instrument import XMLLoader
-from digitalout import *
-
+from hsdio import HSDIO
+from ni_hsdio import HSDIOSession
 
 class PXIError(Exception):
     """
@@ -128,3 +128,16 @@ class HardwareError(PXIError):
         Reference to an instance of the task class where the error occured
         """
         return self._task
+
+
+class HSDIOError(Exception):
+    """
+    Raised for errors coming from NI HSDIO drivers
+    Attributes:
+        error_code : Integer code representing the error state
+        message : message corresponding to the error_code with some traceback info
+    """
+    def __init__(self, error_code, message):
+        self.error_code = error_code
+        self.message = message
+        super().__init__(message)

--- a/pxierrors.py
+++ b/pxierrors.py
@@ -103,7 +103,7 @@ class HardwareError(PXIError):
     
     def __init__(self, device: XMLLoader, task=None, message: str=None):
         """
-        Constructor for HardwareError. 
+        Constructor for HardwareError.
         
         Args:
             device: class or instance of a type that inherits from 
@@ -128,24 +128,3 @@ class HardwareError(PXIError):
         Reference to an instance of the task class where the error occured
         """
         return self._task
-
-    
-class TimeoutError(PXIError):
-    """
-    """
-    
-    pass
-    
-    
-## stuff for testing :
-
-if __name__ == '__main__':
-    
-    do = DAQmxDO(None) # some device instance 
-    try: 
-        node = ET.Element('wumbo')
-        do.load_xml(node)
-    except Exception as e:
-        xml_err = XMLError(do, node)
-        print(xml_err.message)
-        raise xml_err

--- a/pxierrors.py
+++ b/pxierrors.py
@@ -20,7 +20,7 @@ class PXIError(Exception):
     Base class for categorizing device class-level exceptions
     """
 
-    def __init__(self, message: str, device: XMLLoader):
+    def __init__(self, message: str, device: XMLLoader = None, error_code: int = 0):
         """
         Constructor for XMLError. 
         
@@ -31,20 +31,28 @@ class PXIError(Exception):
         self._message = message
         super().__init__(self.message)
         self._device = device
+        self._error_code = error_code
         
     @property
     def device(self) -> XMLLoader:
         """
-        Reference to an instance of the device class where the error occured
+        Reference to an instance of the device class where the error occurred
         """
         return self._device
         
     @property
     def message(self) -> str:
         """
-        Return additional info about the error that occured
+        Return additional info about the error that occurred
         """
         return self._message
+
+    @property
+    def error_code(self) -> int:
+        """
+        Return a code corresponding to the error that occurred
+        """
+        return self._error_code
    
    
 class XMLError(PXIError):
@@ -100,7 +108,7 @@ class HardwareError(PXIError):
         - anything to do with an HSDIOSession
         - setting up triggers for hardware
     """
-    
+
     def __init__(self, device: XMLLoader, task=None, message: str=None):
         """
         Constructor for HardwareError.
@@ -130,7 +138,10 @@ class HardwareError(PXIError):
         return self._task
 
 
-class HSDIOError(Exception):
+# when these error types are handled in their respective device classes,
+# Hardware errors should be raised
+
+class HSDIOError(PXIError):
     """
     Raised for errors coming from NI HSDIO drivers
     Attributes:
@@ -138,6 +149,15 @@ class HSDIOError(Exception):
         message : message corresponding to the error_code with some traceback info
     """
     def __init__(self, error_code, message):
-        self.error_code = error_code
-        self.message = message
-        super().__init__(message)
+        super().__init__(message, error_code=error_code)
+
+
+class IMAQError(PXIError):
+    """
+    Raised for errors coming from NI IMAQ drivers
+    Attributes:
+        error_code : Integer code representing the error state
+        message : message corresponding to the error_code with some traceback info
+    """
+    def __init__(self, error_code, message):
+        super().__init__(message, error_code=error_code)


### PR DESCRIPTION
Redundant return_data variables in PXI class have been removed and bugs in the logic of reading/queuing of data have been fixed. Errored-out devices are now marked as uninitialized so that they are excluded from subsequent measurements until they are reinitialized. Some statements have been wrapped in try/except blocks where useful, and some general clean-up has been done as well. 