### PR TITLE
Meta error handling

### DIFF
--- a/hsdio.py
+++ b/hsdio.py
@@ -217,20 +217,20 @@ class HSDIO(Instrument):
 
         for wf in self.waveformArr:
 
-            self.logger.info(f"wf pre-split : {wf}")
+            # self.logger.info(f"wf pre-split : {wf}")
             wv_arr = wf.wave_split()
             # for each HSDIO card (e.g., Rb experiment has two cards)
             for session, wave in zip(self.sessions, wv_arr):
 
-                self.logger.info(f"post-split : {wave}")
+                # self.logger.info(f"post-split : {wave}")
                 format, data = wave.decompress()
-                self.logger.info(f"format of waveform is {format}")
+                # self.logger.info(f"format of waveform is {format}")
                 try:
                     if format == "WDT":
                         # grouping = HSDIOSession.NIHSDIO_VAL_GROUP_BY_CHANNEL
                         grouping = HSDIOSession.NIHSDIO_VAL_GROUP_BY_SAMPLE
                         
-                        self.logger.info(f"{wave}")
+                        # self.logger.info(f"{wave}")
                         
                         session.write_waveform_wdt(
                             wave.name,

--- a/hsdio.py
+++ b/hsdio.py
@@ -217,10 +217,12 @@ class HSDIO(Instrument):
 
         for wf in self.waveformArr:
 
+            self.logger.info(f"wf pre-split : {wf}")
             wv_arr = wf.wave_split()
             # for each HSDIO card (e.g., Rb experiment has two cards)
             for session, wave in zip(self.sessions, wv_arr):
 
+                self.logger.info(f"post-split : {wave}")
                 format, data = wave.decompress()
                 self.logger.info(f"format of waveform is {format}")
                 try:
@@ -228,7 +230,7 @@ class HSDIO(Instrument):
                         # grouping = HSDIOSession.NIHSDIO_VAL_GROUP_BY_CHANNEL
                         grouping = HSDIOSession.NIHSDIO_VAL_GROUP_BY_SAMPLE
                         
-                        self.logger.info(f"Waveform write: \n name={wave.name} \n samples_per_chan={max(wave.transitions)}")
+                        self.logger.info(f"{wave}")
                         
                         session.write_waveform_wdt(
                             wave.name,

--- a/instrument.py
+++ b/instrument.py
@@ -30,6 +30,8 @@ class XMLLoader(ABC):
             node : optional node so that a second call to load_xml does not have to be made
         """
         self.logger = logging.getLogger(str(self.__class__.__name__))
+        self.logger.setLevel(logging.DEBUG)  # Adjust instrument level logging here
+        # TODO : Set logging level globally. Maybe config file
         if node is not None:
             self.load_xml(node)
 

--- a/ni_hsdio.py
+++ b/ni_hsdio.py
@@ -635,9 +635,9 @@ class HSDIOSession:
                 negative values = Errors
         """
 
-        self.logger.info(f"Python Waveform data is {data}\nlength = {len(data)}")
+        # self.logger.info(f"Python Waveform data is {data}\nlength = {len(data)}")
         c_data = (c_uint8 * len(data))(*data)
-        self.logger.info(f"C Waveform data is {list(c_data)}\n length = {len(list(c_data))}")
+        # self.logger.info(f"C Waveform data is {list(c_data)}\n length = {len(list(c_data))}")
         c_wvfm_name = c_char_p(waveform_name.encode('utf-8'))
         error_code = self.hsdio.niHSDIO_WriteNamedWaveformWDT(
             self.vi,                    # ViSession

--- a/ni_hsdio.py
+++ b/ni_hsdio.py
@@ -635,7 +635,9 @@ class HSDIOSession:
                 negative values = Errors
         """
 
+        self.logger.info(f"Python Waveform data is {data}\nlength = {len(data)}")
         c_data = (c_uint8 * len(data))(*data)
+        self.logger.info(f"C Waveform data is {list(c_data)}\n length = {len(list(c_data))}")
         c_wvfm_name = c_char_p(waveform_name.encode('utf-8'))
         error_code = self.hsdio.niHSDIO_WriteNamedWaveformWDT(
             self.vi,                    # ViSession

--- a/ni_hsdio.py
+++ b/ni_hsdio.py
@@ -98,7 +98,7 @@ class HSDIOSession:
             message = f"{code_type} {error_code} in {traceback_msg}:\n {err_msg}"
 
         if error_code < 0:
-            self.logger.error(message)
+            self.logger.error(message, exc_info=False)
             raise HSDIOError(error_code, message)
         else:
             self.logger.warning(message)
@@ -782,7 +782,7 @@ class HSDIOSession:
         """
 
         if reset:
-            self.reset()
+            self.reset(check_error=check_error)
         error_code = self.hsdio.niHSDIO_close(self.vi)
 
         if error_code != 0 and check_error:

--- a/test_server.py
+++ b/test_server.py
@@ -44,7 +44,8 @@ def setup_logging_handlers():
 if __name__ == '__main__':
     setup_logging_handlers()
     logger = logging.getLogger(__name__)
-    
+    logger.setLevel(logging.DEBUG)
+
     #TODO: add config file to write this to and check config file in future
     port = 9000
     logger.info(f"Default port={port}. \n Hit \'Enter\' for host=localhost "+

--- a/waveform.py
+++ b/waveform.py
@@ -160,7 +160,7 @@ class HSDIOWaveform(Waveform):
         'node' is of type xml.etree.ElementTree.Element, with tag="waveform"
         """
 
-        self.logger.info("Initializing waveform from xml")
+        # self.logger.info("Initializing waveform from xml")
         waveform_attrs = node
         for child in waveform_attrs:
             
@@ -170,20 +170,20 @@ class HSDIOWaveform(Waveform):
                     self.name = child.text
 
                 elif child.tag == "transitions":
-                    self.logger.info(f"writing transitions {child.text}")
+                    # self.logger.info(f"writing transitions {child.text}")
                     t = np.array([x for x in child.text.split(" ")], 
                                  dtype=c_uint32)
                     self.transitions = t
-                    self.logger.info(f"transitions written {self.transitions}")
+                    # self.logger.info(f"transitions written {self.transitions}")
                     self.length = len(self.transitions)
 
                 elif child.tag == "states":
-                    self.logger.info(f"writing states {child.text}")
+                    # self.logger.info(f"writing states {child.text}")
                     states = np.array([[int(x) for x in line.split(" ")]
                                       for line in child.text.split("\n")],
                                       dtype=c_uint32)
                     self.states = states
-                    self.logger.info(f"states writen {self.states}")
+                    # self.logger.info(f"states writen {self.states}")
                     self.check_state_len()
 
                 else:


### PR DESCRIPTION
Fixes recursive error handling and excessive logging caused by trying to access a device session or task reference that had already been closed. Also fixes issues in which a new experiment thread was launched prior shutting down an old one. These are Juan's fixes as implemented in branch HSDIO_Waveform_fix, and I have commented out the excess verbosity in logging introduced for debugging. 