### PR TITLE
Analog input live test

### DIFF
--- a/analogin.py
+++ b/analogin.py
@@ -71,6 +71,7 @@ class AnalogInput(Instrument):
 
                     elif child.tag == "samples_per_measurement":
                         self.samplesPerMeasurement = Instrument.str_to_int(child.text)
+                        self.logger.debug(self.samplesPerMeasurement)
 
                     elif child.tag == "source":
                         self.source = child.text
@@ -143,8 +144,12 @@ class AnalogInput(Instrument):
                     sample_mode=AcquisitionType.FINITE, # default
                     samps_per_chan=self.samplesPerMeasurement)
                 
+                self.logger.debug(f"sampRate = {self.sampleRate} \n"+
+                    f"sampsPerMeasurement = {self.samplesPerMeasurement} \n")
+                
                 # Setup start trigger if configured to wait for one
                 if self.startTrigger.wait_for_start_trigger:
+                    self.logger.debug("Will wait for digital edge trigger")
                     self.task.triggers.start_trigger.cfg_dig_edge_start_trig(
                         trigger_source=self.startTrigger.source,
                         trigger_edge=self.startTrigger.edge)
@@ -194,11 +199,12 @@ class AnalogInput(Instrument):
         if not (self.stop_connections or self.exit_measurement) and self.enable:
         
             try: 
-                # dadmx read 2D DBL N channel N sample. use defaults kwargs. 
+                # daqmx read 2D DBL N channel N sample. use defaults kwargs. 
                 # measurement type inferred from the task virtual channel
-                self.data = self.task.read()
+                self.data = self.task.read(
+                    number_of_samples_per_channel=self.samplesPerMeasurement
+                )
                 
-                # TODO: remove after debugging
                 try:
                     self.logger.debug("aqcuired data:\n"+
                         f"len(data) = {len(self.data)}\n"

--- a/analogin.py
+++ b/analogin.py
@@ -233,23 +233,14 @@ class AnalogInput(Instrument):
 
                 shape_str = ",".join([str(x) for x in data_shape])
 
-                # flatten data to string of bytes. supposed to mimic LabVIEW's Flatten to String VI,
-                # which is inappropriately named. according to the inconsistent docs it either outputs
-                # UTF-8 JSON or binary. this returns bytes and may therefore be wrong.
-                
-                data_string = "".join([str(x) for x in flat_data])
-                self.logger.debug("AI data is " + data_string)
-                
-                # data_bytes = struct.pack('!L', "".join([str(x) for x in flat_data]))
-                # data_string = TCP.bytes_to_str(data_string)
+                data_bytes = struct.pack(f'!{len(flat_data)}d', *flat_data)
 
-                self.data_string = TCP.format_data('AI/dimensions', shape_str) + \
-                    TCP.format_data('AI/data', data_string)
+                self.data_string = (TCP.format_data('AI/dimensions', shape_str) + 
+                                    TCP.format_data('AI/data', data_bytes))
 
             except Exception as e:
                 self.logger.exception(f"Error formatting data from {self.__class__.__name__}")
                 raise e
-
             return self.data_string
             
     def start(self):

--- a/hsdio.py
+++ b/hsdio.py
@@ -322,12 +322,12 @@ class HSDIO(Instrument):
         """
         for wf in self.waveformArr:
 
-            self.logger.debug(f"wf pre-split : {wf}")
+            # self.logger.debug(f"wf pre-split : {wf}")
             wv_arr = wf.wave_split(flip=False)
             # for each HSDIO card (e.g., Rb experiment has two cards)
             for session, wave in zip(self.sessions, wv_arr):
 
-                self.logger.debug(f"post-split : {wave}")
+                # self.logger.debug(f"post-split : {wave}")
                 wave_format, data = wave.decompress()
                 self.logger.debug(f"format of waveform is {wave_format}")
                 try:
@@ -335,7 +335,7 @@ class HSDIO(Instrument):
                         # grouping = HSDIOSession.NIHSDIO_VAL_GROUP_BY_CHANNEL
                         grouping = HSDIOSession.NIHSDIO_VAL_GROUP_BY_SAMPLE
 
-                        self.logger.debug(f"{wave}")
+                        # self.logger.debug(f"{wave}")
 
                         session.write_waveform_wdt(
                             wave.name,

--- a/pxi.py
+++ b/pxi.py
@@ -690,6 +690,7 @@ class PXI:
             try:
                 getattr(dev, method)()  # call the method
             except AttributeError as ae:
+                self.logger.exception(ae)
                 self.logger.warning(f'{dev} does not have method \'{method}\'')
             except HardwareError as he:
                 self.logger.info(

--- a/pxi.py
+++ b/pxi.py
@@ -60,8 +60,8 @@ class PXI:
         self._reset_connection = False
         self._exit_measurement = False
         self.cycle_continuously = False
-        self.return_data = ""
-        self.return_data_queue = ""
+        self.return_data = b""
+        self.return_data_queue = b""
         self.measurement_timeout = 0
         self.keylisten_thread = None
         self.command_queue = Queue(0)  # 0 indicates no maximum queue length enforced.
@@ -165,7 +165,7 @@ class PXI:
 
             except Empty:
                 self.exit_measurement = False
-                self.return_data = ""  # clear the return data
+                self.return_data = b""  # clear the return data
 
                 if self.cycle_continuously and self.active_devices > 0:
                     self.logger.debug("Entering cycle continously...")
@@ -214,7 +214,7 @@ class PXI:
                     if child.tag == "measure":
                         # if no data available, take one measurement. Otherwise,
                         # use the most recent data.
-                        if self.return_data_queue == "":
+                        if self.return_data_queue == b"":
                             self.measurement()
                         else:
                             self.return_data = self.return_data_queue
@@ -317,8 +317,8 @@ class PXI:
         self.tcp.send_message(self.return_data)
 
         # clear the return data
-        self.return_data = ""
-        self.return_data_queue = ""
+        self.return_data = b""
+        self.return_data_queue = b""
 
     def data_to_xml(self) -> str:
         """
@@ -331,7 +331,7 @@ class PXI:
             'return_data': concatenated string of xml-formatted data
         """
 
-        return_data = ""
+        return_data = b""
 
         # the devices which have a method named 'data_out' which returns a str
         devices = [

--- a/tcp.py
+++ b/tcp.py
@@ -125,7 +125,10 @@ class TCP:
         
         if not self.stop_connections: # and msg_str:
             try:
-                self.current_connection.send(f"MESG{TCP.format_message(msg_str)}".encode())
+                self.logger.info("encoding message")
+                encoded = b"MESG"+TCP.format_message(msg_str)
+                self.current_connection.send(encoded)
+                self.logger.info("message sent")
             except Exception:
                 self.logger.exception("Issue sending message back to CsPy.")
                 self.reset_connection = True
@@ -134,7 +137,7 @@ class TCP:
 
 
     @staticmethod
-    def format_message(message: str) -> str:
+    def format_message(message) -> bytes:
         """
         Formats a message according to how CsPy expects to receive it. This is done by pre-prending
         the length of the message to the message in byte form
@@ -144,10 +147,13 @@ class TCP:
         Returns:
             formatted message string
         """
-        return f"{TCP.bytes_to_str(struct.pack('!L', len(message)))}{message}"
+        if isinstance(message, str):
+            message = message.encode()
+        return struct.pack('!L', len(message)) + message
+
 
     @staticmethod
-    def format_data(name, data) -> str:
+    def format_data(name, data) -> bytes:
         """
         Formats a bit of data according to how CsPy expects to receive it.
         Args:
@@ -157,7 +163,7 @@ class TCP:
         Returns:
             formatted string that CsPy can parse
         """
-        return f"{TCP.format_message(name)}{TCP.format_message(data)}"
+        return TCP.format_message(name)+TCP.format_message(data)
 
     @staticmethod
     def bytes_to_str(data) -> str:


### PR DESCRIPTION
Fixes AnalogInput bugs -- the correct number of measurements are acquired and correctly encoded such that CsPy can understand the data. I've tested running actual experiments as well as just cycling continuously, and toggling between the two in a given server session and have dealt with all bugs that I could find, notably those related to proper shutdown of the device on quitting the server. Please test on your experiments. 