### PR TITLE
Correctly compute bf_diff when image buffers roll over

### DIFF
--- a/hamamatsu.py
+++ b/hamamatsu.py
@@ -447,7 +447,7 @@ class Hamamatsu(Instrument):
             ms = f"{e}\nError Reading out session status during measurement"
             raise HardwareError(self, self.session, ms)
 
-        bf_dif = last_buf_num - self.last_frame_acquired
+        bf_dif = (last_buf_num - self.last_frame_acquired) % self.num_img_buffers
         not_enough_buffers = bf_dif > self.num_img_buffers
 
         self.logger.debug(f"Last Frame : {self.last_frame_acquired}\n"

--- a/hamamatsu.py
+++ b/hamamatsu.py
@@ -471,10 +471,11 @@ class Hamamatsu(Instrument):
 
         for i in range(bf_dif):
             frame_ind += 1
+            frame_ind %= self.num_img_buffers
             self.logger.debug("Acquiring a new available image\n"
                               f" Reading buffer number {frame_ind}")
             try:
-                er_c, img = self.session.session_copy_buffer(frame_ind,wait_for_next=False)
+                er_c, img = self.session.session_copy_buffer(frame_ind, wait_for_next=False)
             except IMAQError as e:
                 self.last_frame_acquired = last_buf_num
                 ms = f"{e}\nError acquiring buffer number {frame_ind} measurement abandoned"


### PR DESCRIPTION
Currently the Hamamatsu class attempts to warn the user if too few or too many shots were taken during a measurement by checking the difference between the index of the last image buffer read during the current measurement, and the last image buffer read during the previous measurement.
The issue is that when the buffer index rolls over the buffer index jumps from some large number (around the size of the number of buffer indices that were prepared) to nearly 0. 
Currently 100 buffer indices are prepared and there are two shots per measurements, so the jump is from index 98 to index 0.
This erroneously logs a warning, and may obfuscate real, experiment harming behavior.

The erroneous error is below.
![image](https://user-images.githubusercontent.com/26193907/91887382-5670e700-ec50-11ea-97a0-ce5308649079.png)

Fix is the addition of a % operator in the right spot.