### PR TITLE
Shutdown Restructure

### DIFF
--- a/analogin.py
+++ b/analogin.py
@@ -271,14 +271,11 @@ class AnalogInput(Instrument):
         """
         Stop the task
         """
-        
         if self.task is not None:
             msg = ""
             try:
-                # be nice and attempt to wait for the measurement to end
                 try:
-                    while not self.is_done():
-                        pass
+                    self.task.stop()
                 except DaqWarning as e:
                     if e.error_code == DAQmxWarnings.STOPPED_BEFORE_DONE.value:
                         pass
@@ -294,7 +291,6 @@ class AnalogInput(Instrument):
         """
         Close the task
         """
-        
         if self.task is not None:
             self.logger.info(self.task.name)
 

--- a/analogout.py
+++ b/analogout.py
@@ -276,34 +276,23 @@ class AnalogOutput(Instrument):
         """
         Stop the task
         """
-        
         if self.task is not None:
-            msg = ""
             try:
-                # be nice and attempt to wait for the measurement to end
-                try:
-                    while not self.is_done():
-                        pass
-                except DaqWarning as e:
-                    if e.error_code == DAQmxWarnings.STOPPED_BEFORE_DONE.value:
-                        pass
-                                            
                 self.task.stop()
             except DaqError as e:
                 if not e.error_code == DAQmxErrors.INVALID_TASK.value:
                     msg = f'\n {self.__class__.__name__} failed to stop current task'
                     self.logger.warning(msg)
                     self.logger.exception(e)
+            except DaqWarning as e:
+                if e.error_code == DAQmxWarnings.STOPPED_BEFORE_DONE.value:
+                    pass
 
     def close(self):
         """
         Close the task
         """
-
-        
         if self.task is not None:
-            self.logger.info(self.task.name)
-
             self.is_initialized = False
             try:
                 self.task.close()

--- a/digitalin.py
+++ b/digitalin.py
@@ -43,8 +43,8 @@ class TTLInput(Instrument):
         
         self.is_initialized = False
         
-        assert (node.tag == self.expectedRoot,
-                f"Expected tag <{self.expectedRoot}>, but received <{node.tag}>")
+        assert node.tag == self.expectedRoot, \
+                f"Expected tag <{self.expectedRoot}>, but received <{node.tag}>"
         
         if not (self.exit_measurement or self.stop_connections):
 

--- a/digitalin.py
+++ b/digitalin.py
@@ -226,7 +226,7 @@ class TTLInput(Instrument):
         Stop the task
         """
         
-        if self.enable:
+        if self.task is not None:
             try:          
                 self.task.stop()
                 self.logger.debug(f"stopped {self.__class__.__name__} task")
@@ -239,11 +239,8 @@ class TTLInput(Instrument):
     def close(self):
         """
         Close the task
-        """
-        
+        """   
         if self.task is not None:
-            self.logger.info(self.task.name)
-        
             try:
                 self.task.close()
             except DaqError as e:

--- a/digitalout.py
+++ b/digitalout.py
@@ -198,9 +198,8 @@ class DAQmxDO(Instrument):
     def stop(self):
         """
         Stop the task
-        """
-        
-        if self.enable:
+        """  
+        if self.task is not None:
             try:
                 self.task.stop()
             except DaqError as e:
@@ -211,8 +210,7 @@ class DAQmxDO(Instrument):
     def close(self):
         """
         Close the task
-        """
-        
+        """  
         if self.task is not None:
             try:
                 self.task.close()

--- a/hamamatsu.py
+++ b/hamamatsu.py
@@ -551,6 +551,7 @@ class Hamamatsu(Instrument):
 
         return hm_str
 
+
     def close(self):
         """
         Closes the Hamamatsu Imaq session gracefully

--- a/hsdio.py
+++ b/hsdio.py
@@ -271,39 +271,34 @@ class HSDIO(Instrument):
         """
         Abort the session
         """
-        self.logger.debug("Stopping operation")
-        if self.enable:
-            for session in self.sessions:
-                try:
-                    session.abort()
-                    self.logger.debug("Aborted an HSDIO session")
-                except HSDIOError as e:
-                    if e.error_code == HSDIO.HSDIO_ERR_BSESSION:
-                        self.logger.warning(
-                            f"Tried to abort {session}, but it does not exist"
-                        )
-                    else:
-                        raise HardwareError(self, session, message=e.message)
+        for session in self.sessions:
+            try:
+                session.abort()
+                self.logger.debug("Aborted an HSDIO session")
+            except HSDIOError as e:
+                if e.error_code == HSDIO.HSDIO_ERR_BSESSION:
+                    self.logger.warning(
+                        f"Tried to abort {session}, but it does not exist"
+                    )
+                else:
+                    raise HardwareError(self, session, message=e.message)
 
     def close(self):
         """
         Close the session
         """
-
-        self.logger.debug("Closing HSDIO operation")
-        if self.enable:
-            self.is_initialized = False
-            for session in self.sessions:
-                try:
-                    session.close(check_error=True)
-                    self.logger.debug("Closed an HSDIO session")
-                except HSDIOError as e:
-                    if e.error_code == HSDIO.HSDIO_ERR_BSESSION:
-                        self.logger.warning(
-                            f"Tried to close {session}, but it does not exist"
-                        )
-                    else:
-                        raise HardwareError(self, session, message=e.message)
+        self.is_initialized = False
+        for session in self.sessions:
+            try:
+                session.close(check_error=True)
+                self.logger.debug("Closed an HSDIO session")
+            except HSDIOError as e:
+                if e.error_code == HSDIO.HSDIO_ERR_BSESSION:
+                    self.logger.warning(
+                        f"Tried to close {session}, but it does not exist"
+                    )
+                else:
+                    raise HardwareError(self, session, message=e.message)
                     
     def log_settings(self, wf_arr, wf_names):  # TODO : @Juan Implement
         pass

--- a/keylistener.py
+++ b/keylistener.py
@@ -20,8 +20,8 @@ class KeyListener(Thread):
             key = msvcrt.getwch()
             self.on_key_press(key)
             if key == 'q':
-                print("Closing KeyListener Thread")
                 self.running = False
+
                                     
     def end(self):
         """End this thread"""

--- a/keylistener.py
+++ b/keylistener.py
@@ -2,26 +2,27 @@ import msvcrt
 from threading import Thread
 
 class KeyListener(Thread):
-	"""
-	Thread class for getting keyboard input in Windows command prompt
-	"""
-	
-	def __init__(self, on_key_press, quitch='q'):
-		self.running = False
-		self.on_key_press = on_key_press
-		self.quitch = quitch
-		super(KeyListener, self).__init__()
-		
-	def run(self):
-		self.running = True
-		
-		while self.running: 
-			key = msvcrt.getwch()
-			
-			self.on_key_press(key)
-			if key == 'q': 
-				self.running = False
-									
-	def end(self):
-		"""End this thread"""
-		self.running = False
+    """
+    Thread class for getting keyboard input in Windows command prompt
+    """
+    
+    def __init__(self, on_key_press, quitch='q'):
+        super(KeyListener, self).__init__(name="KeyListener")
+        self.running = False
+        self.on_key_press = on_key_press
+        self.quitch = quitch
+
+        
+    def run(self):
+        self.running = True
+        
+        while self.running:
+            key = msvcrt.getwch()
+            self.on_key_press(key)
+            if key == 'q':
+                print("Closing KeyListener Thread")
+                self.running = False
+                                    
+    def end(self):
+        """End this thread"""
+        self.running = False

--- a/pxi.py
+++ b/pxi.py
@@ -339,7 +339,7 @@ class PXI:
         devices = [
             self.hamamatsu,
             # self.counters, #TODO: implement
-            self.ttl,
+            #self.ttl,
             self.analog_input
             # self.demo # not implemented, and debatable whether it needs to be
         ]
@@ -438,7 +438,7 @@ class PXI:
             self.hamamatsu,
             self.analog_input,
             self.analog_output,
-            self.ttl
+            #self.ttl
             # self.counters # TODO: implement Counters.start
         ]
 
@@ -456,7 +456,7 @@ class PXI:
             # self.daqmx_do,
             self.analog_input,
             self.analog_output,
-            self.ttl
+            #self.ttl
             # self.counters # TODO: implement Counters.stop
         ]
 
@@ -474,7 +474,7 @@ class PXI:
             self.hamamatsu,
             self.analog_input,
             self.analog_output,
-            self.ttl
+            #self.ttl
             # self.counters # TODO: implement Counters.stop
         ]
 
@@ -515,7 +515,7 @@ class PXI:
                 self.hsdio,
                 self.analog_output,
                 self.analog_input,
-                self.ttl,
+                #self.ttl,
                 # self.daqmx_do
             ]
 

--- a/pxi.py
+++ b/pxi.py
@@ -474,7 +474,7 @@ class PXI:
             self.hamamatsu,
             self.analog_input,
             self.analog_output,
-            #self.ttl
+            self.ttl
             # self.counters # TODO: implement Counters.stop
         ]
 

--- a/tcp.py
+++ b/tcp.py
@@ -14,6 +14,7 @@ class TCP:
         self.current_connection = None
         self.network_thread = None
         self.pxi = pxi
+        self.seeking_connection = False
 
     @property
     def reset_connection(self) -> bool:
@@ -50,7 +51,9 @@ class TCP:
 
             # TODO: entering q in cmd line should terminate this process
             self.logger.info("Attempting to accept connection request.")
+            self.seeking_connection = True
             self.current_connection, client_address = self.listening_socket.accept()
+            self.seeking_connection = False
             self.logger.info(f"Started connection with {client_address}")
             while not (self.pxi.reset_connection or self.stop_connections):
                 try:
@@ -64,7 +67,7 @@ class TCP:
                     
             self.logger.info(f"Closing connection with {client_address}")
             self.current_connection.close()
-
+        self.logger.info("Closing Networking Thread")
         self.listening_socket.close()
 
     def receive_message(self):
@@ -135,7 +138,13 @@ class TCP:
         else:
             self.logger.warning("tried to send a message but the connection is stopped :'(")
 
+            
+    def abort(self):
+        kill_socket = socket.socket()
+        kill_socket.connect(('127.0.0.1', 9000))
+        kill_socket.close()
 
+    
     @staticmethod
     def format_message(message) -> bytes:
         """


### PR DESCRIPTION
Restructures the shutdown procedure as well as changes the stop and close methods for several devices to ensure that the server actually shuts down and the resources are actually released when we press "q" to shut down the server. As far as I can tell, the only time pressing q won't work is prior to the key-listener being set up, which is as expected.

Brief description of what actually changed:

Devices in PXI.stop_tasks, PXI.start_tasks, PXI.close_tasks, etc. were updated so that they actually contained all devices with those methods.
When Q is pressed, the keyboard listener thread switches the global stop connections and exit measurement variables to true and passes off the task of actually releasing resources to the experiment thread instead of doing that itself.
If Q is pressed before a connection is made, a dummy connection will be formed and closed to allow the network thread to die a peaceful death.
Several devices had stop and close methods reworked to more aggressively enforce releasing resources.

Fixes #25 